### PR TITLE
Add dnstable_unconvert utility.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Makefile
 Makefile.in
 TAGS
 dnstable_convert
+dnstable_unconvert

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,20 @@ dnstable_convert_LDADD = \
 	$(libnmsg_LIBS) \
 	$(libwdns_LIBS) 
 
+bin_PROGRAMS += dnstable_unconvert
+
+dnstable_unconvert_SOURCES = dnstable_unconvert.c
+
+dnstable_unconvert_CFLAGS = $(libnmsg_CFLAGS) $(libdnstable_CFLAGS) \
+			  $(libmtbl_CFLAGS) $(libwdns_CFLAGS)
+
+dnstable_unconvert_LDADD = \
+	$(libdnstable_LIBS) \
+	$(libmtbl_LIBS) \
+	$(libnmsg_LIBS) \
+	$(libwdns_LIBS) 
+
+
 if BUILD_MAN
 SUFFIXES = .1.txt .3.txt .5.txt .7.txt .1 .3 .5 .7
 
@@ -44,7 +58,9 @@ ASCIIDOC_PROCESS = $(AM_V_GEN) $(ASCIIDOC) -f manpage --no-xmllint --asciidoc-op
 endif
 
 dist_man_MANS = \
-	man/dnstable_convert.1
+	man/dnstable_convert.1 \
+	man/dnstable_unconvert.1
 
 EXTRA_DIST += \
-	man/dnstable_convert.1.txt
+	man/dnstable_convert.1.txt \
+	man/dnstable_unconvert.1.txt

--- a/dnstable_unconvert.c
+++ b/dnstable_unconvert.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2019 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <assert.h>
+
+#include <dnstable.h>
+#include <mtbl.h>
+#include <nmsg.h>
+#include <wdns.h>
+
+static nmsg_message_t entry_to_nmsg(struct dnstable_entry *, const uint8_t *, size_t);
+static nmsg_msgmod_t sie_dnsdedupe;
+
+int main(int ac, char **av) {
+	int fd;
+	nmsg_output_t out;
+	nmsg_res nres;
+
+	struct mtbl_reader *r;
+	struct mtbl_iter *it;
+	const uint8_t *key, *val;
+	size_t i, len_key, len_val;
+
+	if (ac != 3) {
+		fprintf(stderr, "Usage: %s <input.mtbl> <output.nmsg>\n", av[0]);
+		exit(1);
+	}
+
+	nres = nmsg_init();
+	assert(nres == nmsg_res_success);
+
+	sie_dnsdedupe = nmsg_msgmod_lookup_byname("sie", "dnsdedupe");
+	if (sie_dnsdedupe == NULL) {
+		fprintf(stderr, "Failed to load sie:dnsdedupe module\n");
+		exit(1);
+	}
+
+	fd = open(av[2], O_WRONLY|O_CREAT|O_EXCL, 0640);
+	if (fd < 0) {
+		fprintf(stderr, "open(%s) failed: %s\n", av[2], strerror(errno));
+		exit(1);
+	}
+
+	out = nmsg_output_open_file(fd, NMSG_WBUFSZ_MAX);
+	assert(out != NULL);
+
+	r = mtbl_reader_init(av[1], NULL);
+	assert(r != NULL);
+	it = mtbl_source_get_prefix(mtbl_reader_source(r), (const uint8_t *)"\x00", 1);
+	assert(it != NULL);
+
+	while (mtbl_iter_next(it, &key, &len_key, &val, &len_val) == mtbl_res_success) {
+		struct dnstable_entry *e;
+		nmsg_message_t m;
+
+		e = dnstable_entry_decode(key, len_key, val, len_val);
+		assert(e != NULL);
+
+		m = entry_to_nmsg(e, val, len_val);
+
+		nres = nmsg_output_write(out, m);
+		assert(nres == nmsg_res_success);
+
+		nmsg_message_destroy(&m);
+		dnstable_entry_destroy(&e);
+	}
+
+	nmsg_output_close(&out);
+	mtbl_iter_destroy(&it);
+	mtbl_reader_destroy(&r);
+
+}
+
+static nmsg_message_t entry_to_nmsg(struct dnstable_entry *e, const uint8_t *data, size_t len_data) {
+	const uint8_t *rrname, *bailiwick;
+	size_t len_rrname, len_bailiwick;
+	uint16_t rrtype;
+	uint16_t rrclass = WDNS_CLASS_IN;
+	size_t i, n_rdata;
+	dnstable_res dres;
+	nmsg_res nres;
+
+	uint32_t nm_time_first, nm_time_last, nm_count;
+
+	nmsg_message_t m = nmsg_message_init(sie_dnsdedupe);
+	assert(m != NULL);
+
+	nres = nmsg_message_set_field(m, "rrclass", 0, (const uint8_t *)&rrclass, sizeof(rrclass));
+	assert(nres == nmsg_res_success);
+
+	dres = dnstable_entry_get_rrname(e, &rrname, &len_rrname);
+	assert(dres == dnstable_res_success);
+	nres = nmsg_message_set_field(m, "rrname", 0, rrname, len_rrname);
+	assert(nres == nmsg_res_success);
+
+	dres = dnstable_entry_get_rrtype(e, &rrtype);
+	assert(dres == dnstable_res_success);
+	nres = nmsg_message_set_field(m, "rrtype", 0, (const uint8_t *)&rrtype, sizeof(rrtype));
+	assert(nres == nmsg_res_success);
+
+	dres = dnstable_entry_get_bailiwick(e, &bailiwick, &len_bailiwick);
+	nres = nmsg_message_set_field(m, "bailiwick", 0, bailiwick, len_bailiwick);
+	assert(nres == nmsg_res_success);
+
+	dres = dnstable_entry_get_num_rdata(e, &n_rdata);
+	assert(dres == dnstable_res_success);
+	for (i = 0; i < n_rdata; i++) {
+		const uint8_t *rdata;
+		size_t len_rdata;
+
+		dres = dnstable_entry_get_rdata(e, i, &rdata, &len_rdata);
+		assert(dres == dnstable_res_success);
+		nres = nmsg_message_set_field(m, "rdata", i, rdata, len_rdata);
+		assert(nres == nmsg_res_success);
+	}
+
+	data += mtbl_varint_decode32(data, &nm_time_first);
+	data += mtbl_varint_decode32(data, &nm_time_last);
+	data += mtbl_varint_decode32(data, &nm_count);
+
+	nres = nmsg_message_set_field(m, "time_first", 0,
+					(const uint8_t *)&nm_time_first,
+					sizeof(nm_time_first));
+	assert(nres == nmsg_res_success);
+	nres = nmsg_message_set_field(m, "time_last", 0,
+					(const uint8_t *)&nm_time_last,
+					sizeof(nm_time_last));
+	assert(nres == nmsg_res_success);
+	nres = nmsg_message_set_field(m, "count", 0,
+					(const uint8_t *)&nm_count,
+					sizeof(nm_count));
+	assert(nres == nmsg_res_success);
+
+	return m;
+}

--- a/dnstable_unconvert.c
+++ b/dnstable_unconvert.c
@@ -144,9 +144,21 @@ static nmsg_message_t entry_to_nmsg(struct dnstable_entry *e, const uint8_t *dat
 	 *      whereas the underlying count value is set to zero for
 	 *      INSERTION records.
 	 */
-	data += mtbl_varint_decode32(data, &nm_time_first);
-	data += mtbl_varint_decode32(data, &nm_time_last);
-	data += mtbl_varint_decode32(data, &nm_count);
+
+#define decode(v) do {							\
+	unsigned vi_len = mtbl_varint_length_packed(data, len_data);	\
+	uint64_t vi_val;						\
+	assert(vi_len > 0);						\
+	len_data -= vi_len;						\
+	data += mtbl_varint_decode64(data, &vi_val);			\
+	v = (uint32_t)vi_val;						\
+} while(0);
+
+	decode(nm_time_first);
+	decode(nm_time_last);
+	decode(nm_count);
+
+#undef decode
 
 	nres = nmsg_message_set_field(m, "time_first", 0,
 					(const uint8_t *)&nm_time_first,

--- a/dnstable_unconvert.c
+++ b/dnstable_unconvert.c
@@ -133,6 +133,17 @@ static nmsg_message_t entry_to_nmsg(struct dnstable_entry *e, const uint8_t *dat
 		assert(nres == nmsg_res_success);
 	}
 
+	/*
+	 * We decode the value triplet here instead of using the dnstable_entry
+	 * times and counts for two reasons:
+	 *
+	 *   1) The dnstable entry values are 64-bit integers, whereas the
+	 *      nmsg fields are 32 bit integers.
+	 *
+	 *   2) The dnstable_entry count will never be presented as zero,
+	 *      whereas the underlying count value is set to zero for
+	 *      INSERTION records.
+	 */
 	data += mtbl_varint_decode32(data, &nm_time_first);
 	data += mtbl_varint_decode32(data, &nm_time_last);
 	data += mtbl_varint_decode32(data, &nm_count);

--- a/dnstable_unconvert.c
+++ b/dnstable_unconvert.c
@@ -25,6 +25,7 @@
 #include <dnstable.h>
 #include <mtbl.h>
 #include <nmsg.h>
+#include <nmsg/sie/dnsdedupe.pb-c.h>
 #include <wdns.h>
 
 static nmsg_message_t entry_to_nmsg(struct dnstable_entry *, const uint8_t *, size_t);
@@ -95,6 +96,7 @@ static nmsg_message_t entry_to_nmsg(struct dnstable_entry *e, const uint8_t *dat
 	size_t len_rrname, len_bailiwick;
 	uint16_t rrtype;
 	uint16_t rrclass = WDNS_CLASS_IN;
+	uint32_t msgtype = NMSG__SIE__DNS_DEDUPE_TYPE__EXPIRATION;
 	size_t i, n_rdata;
 	dnstable_res dres;
 	nmsg_res nres;
@@ -171,6 +173,14 @@ static nmsg_message_t entry_to_nmsg(struct dnstable_entry *e, const uint8_t *dat
 	nres = nmsg_message_set_field(m, "count", 0,
 					(const uint8_t *)&nm_count,
 					sizeof(nm_count));
+	assert(nres == nmsg_res_success);
+
+	if (nm_count == 0)
+		msgtype = NMSG__SIE__DNS_DEDUPE_TYPE__INSERTION;
+
+	nres = nmsg_message_set_field(m, "type", 0,
+					(const uint8_t *)&msgtype,
+					sizeof(msgtype));
 	assert(nres == nmsg_res_success);
 
 	return m;

--- a/man/dnstable_unconvert.1
+++ b/man/dnstable_unconvert.1
@@ -2,12 +2,12 @@
 .\"     Title: dnstable_unconvert
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 11/18/2019
+.\"      Date: 12/03/2019
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DNSTABLE_UNCONVERT" "1" "11/18/2019" "\ \&" "\ \&"
+.TH "DNSTABLE_UNCONVERT" "1" "12/03/2019" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,9 +31,11 @@
 dnstable_unconvert \- convert dnstable MTBL data to passive DNS NMSG format
 .SH "SYNOPSIS"
 .sp
-\fBdnstable_unconvert\fR \fIDB\-FILE\fR \fINMSG\-FILE\fR
+\fBdnstable_unconvert\fR [\-z] \fIDB\-FILE\fR \fINMSG\-FILE\fR
 .SH "DESCRIPTION"
 .sp
 Converts passive DNS data from MTBL format to NMSG format\&. The RRSET entries in the dnstable MTBL file \fIDB\-FILE\fR are converted to NMSG \fIsie:dnsdedupe\fR format and written to the output file \fINMSG\-FILE\fR\&.
 .sp
 \fBdnstable_unconvert\fR will create the file \fINMSG\-FILE\fR, which must not exist\&.
+.sp
+If the \fB\-z\fR option is given, \fBdnstable_unconvert\fR will write compressed data to \fINMSG\-FILE\fR\&.

--- a/man/dnstable_unconvert.1
+++ b/man/dnstable_unconvert.1
@@ -31,7 +31,9 @@
 dnstable_unconvert \- convert dnstable MTBL data to passive DNS NMSG format
 .SH "SYNOPSIS"
 .sp
-\fBdnstable_convert\fR \fIDB\-FILE\fR \fINMSG\-FILE\fR
+\fBdnstable_unconvert\fR \fIDB\-FILE\fR \fINMSG\-FILE\fR
 .SH "DESCRIPTION"
 .sp
 Converts passive DNS data from MTBL format to NMSG format\&. The RRSET entries in the dnstable MTBL file \fIDB\-FILE\fR are converted to NMSG \fIsie:dnsdedupe\fR format and written to the output file \fINMSG\-FILE\fR\&.
+.sp
+\fBdnstable_unconvert\fR will create the file \fINMSG\-FILE\fR, which must not exist\&.

--- a/man/dnstable_unconvert.1
+++ b/man/dnstable_unconvert.1
@@ -1,0 +1,37 @@
+'\" t
+.\"     Title: dnstable_unconvert
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 11/18/2019
+.\"    Manual: \ \&
+.\"    Source: \ \&
+.\"  Language: English
+.\"
+.TH "DNSTABLE_UNCONVERT" "1" "11/18/2019" "\ \&" "\ \&"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+dnstable_unconvert \- convert dnstable MTBL data to passive DNS NMSG format
+.SH "SYNOPSIS"
+.sp
+\fBdnstable_convert\fR \fIDB\-FILE\fR \fINMSG\-FILE\fR
+.SH "DESCRIPTION"
+.sp
+Converts passive DNS data from MTBL format to NMSG format\&. The RRSET entries in the dnstable MTBL file \fIDB\-FILE\fR are converted to NMSG \fIsie:dnsdedupe\fR format and written to the output file \fINMSG\-FILE\fR\&.

--- a/man/dnstable_unconvert.1.txt
+++ b/man/dnstable_unconvert.1.txt
@@ -6,10 +6,12 @@ dnstable_unconvert - convert dnstable MTBL data to passive DNS NMSG format
 
 == SYNOPSIS ==
 
-^dnstable_convert^ 'DB-FILE' 'NMSG-FILE'
+^dnstable_unconvert^ 'DB-FILE' 'NMSG-FILE'
 
 == DESCRIPTION ==
 
 Converts passive DNS data from MTBL format to NMSG format.  The RRSET entries
 in the dnstable MTBL file 'DB-FILE' are converted to NMSG 'sie:dnsdedupe' format
 and written to the output file 'NMSG-FILE'.
+
+^dnstable_unconvert^ will create the file 'NMSG-FILE', which must not exist.

--- a/man/dnstable_unconvert.1.txt
+++ b/man/dnstable_unconvert.1.txt
@@ -1,0 +1,15 @@
+= dnstable_unconvert(1) =
+
+== NAME ==
+
+dnstable_unconvert - convert dnstable MTBL data to passive DNS NMSG format
+
+== SYNOPSIS ==
+
+^dnstable_convert^ 'DB-FILE' 'NMSG-FILE'
+
+== DESCRIPTION ==
+
+Converts passive DNS data from MTBL format to NMSG format.  The RRSET entries
+in the dnstable MTBL file 'DB-FILE' are converted to NMSG 'sie:dnsdedupe' format
+and written to the output file 'NMSG-FILE'.

--- a/man/dnstable_unconvert.1.txt
+++ b/man/dnstable_unconvert.1.txt
@@ -6,7 +6,7 @@ dnstable_unconvert - convert dnstable MTBL data to passive DNS NMSG format
 
 == SYNOPSIS ==
 
-^dnstable_unconvert^ 'DB-FILE' 'NMSG-FILE'
+^dnstable_unconvert^ [-z] 'DB-FILE' 'NMSG-FILE'
 
 == DESCRIPTION ==
 
@@ -15,3 +15,6 @@ in the dnstable MTBL file 'DB-FILE' are converted to NMSG 'sie:dnsdedupe' format
 and written to the output file 'NMSG-FILE'.
 
 ^dnstable_unconvert^ will create the file 'NMSG-FILE', which must not exist.
+
+If the ^-z^ option is given, ^dnstable_unconvert^ will write compressed data
+to 'NMSG-FILE'.


### PR DESCRIPTION
dnstable_unconvert converts the RRSET entries of a dnstable file
to the equivalent NMSG format.