### PR TITLE
Misc. fixes to next

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_SYS_LARGEFILE
 AC_CONFIG_MACRO_DIR([m4])
 AM_SILENT_RULES([yes])
 
-my_CFLAGS="-Wall \
+my_CFLAGS="-Wall -Wformat \
 -Wmissing-declarations -Wmissing-prototypes \
 -Wnested-externs -Wpointer-arith \
 -Wpointer-arith -Wsign-compare -Wchar-subscripts \

--- a/dnstable_convert.c
+++ b/dnstable_convert.c
@@ -378,7 +378,7 @@ do_read(void)
 		if (res == nmsg_res_eof)
 			break;
 		if (res != nmsg_res_success) {
-			fprintf(stderr, "Error reading nmsg input: %s", nmsg_res_lookup(res));
+			fprintf(stderr, "Error reading nmsg input: %s\n", nmsg_res_lookup(res));
 			exit(EXIT_FAILURE);
 		}
 

--- a/dnstable_convert.c
+++ b/dnstable_convert.c
@@ -576,6 +576,11 @@ main(int argc, char **argv)
 	do_write();
 	do_stats();
 
+	if (count_entries == 0) {
+		fprintf(stderr, "no DNS entries generated, unlinking %s\n", db_fname);
+		unlink(db_fname);
+	}
+
 	if (count_entries_dnssec == 0) {
 		fprintf(stderr, "no DNSSEC entries generated, unlinking %s\n", db_dnssec_fname);
 		unlink(db_dnssec_fname);

--- a/dnstable_unconvert.c
+++ b/dnstable_unconvert.c
@@ -38,7 +38,7 @@ static uint64_t		count_rrsets;
 static struct timespec	start_time;
 
 static void usage(const char *progname) {
-	fprintf(stderr, "Usage: %s [-z] <input.mtbl> <output.nmsg>\n", progname);
+	fprintf(stderr, "Usage: %s [-z] <DB FILE> <NMSG FILE>\n", progname);
 	exit(1);
 }
 

--- a/dnstable_unconvert.c
+++ b/dnstable_unconvert.c
@@ -84,7 +84,11 @@ int main(int ac, char **av) {
 	nmsg_output_set_zlibout(out, zlibout);
 
 	r = mtbl_reader_init(av[0], NULL);
-	assert(r != NULL);
+	if (r == NULL) {
+		fprintf(stderr, "Failed to open %s as mtbl file\n", av[0]);
+		exit(1);
+	}
+
 	it = mtbl_source_get_prefix(mtbl_reader_source(r), (const uint8_t *)"\x00", 1);
 	assert(it != NULL);
 


### PR DESCRIPTION
* Change some common / anticipated failures in dnstable_convert / dnstable_unconvert from assertions to error messages

* Add progress output to dnstable_convert

* Make dnstable_unconvert usage output consistent with dnstable_convert

* Make dnstable_convert remove empty dns mtbl file, as with dnssec.