### PR TITLE
Index NSEC records

### DIFF
--- a/dnstable_convert.c
+++ b/dnstable_convert.c
@@ -385,6 +385,9 @@ process_rdata_slice(Nmsg__Sie__DnsDedupe *dns, size_t i, ubuf *key, ubuf *val)
 	case WDNS_TYPE_SRV:
 		offset = 6;	/* skip SRV priority, weight, port */
 		break;
+        case WDNS_TYPE_NSEC:
+		offset = 0;	/* skip later */
+		break;
 	default:
 		return;
 	}
@@ -407,6 +410,7 @@ process_rdata_slice(Nmsg__Sie__DnsDedupe *dns, size_t i, ubuf *key, ubuf *val)
 		break;
 	case WDNS_TYPE_SVCB:
 	case WDNS_TYPE_HTTPS:
+        case WDNS_TYPE_NSEC:
 		res = wdns_len_uname(dns->rdata[i].data + offset,
 				     dns->rdata[i].data + dns->rdata[i].len,
 				     &len);

--- a/dnstable_convert.c
+++ b/dnstable_convert.c
@@ -469,6 +469,9 @@ process_rdata_name_rev(Nmsg__Sie__DnsDedupe *dns, size_t i, ubuf *key, ubuf *val
 	wdns_res res;
 
 	switch (dns->rrtype) {
+        case WDNS_TYPE_NSEC:
+		do_downcase = true;
+		/* fallthrough */
 	case WDNS_TYPE_SOA:
 		if (len == 0)
 			return;


### PR DESCRIPTION
Will now output ENTRY_TYPE_RDATA_NAME_REV and ENTRY_TYPE_RDATA slice records for NSEC records.

This allows the following queries to work where previously they would not return any data.
```
$ dnstable_lookup -j rdata name i.mcj4.iad1.fsi.\*
{"count":13,"time_first":1637014235,"time_last":1637071900,"rrname":"mcj4.iad1.fsi.io.","rrtype":"NSEC","rdata":"i.mcj4.iad1.fsi.io. A RRSIG NSEC"}

$ dnstable_lookup -j rdata name \*.mcj4.iad1.fsi.io.
{"count":26,"time_first":1637014235,"time_last":1637071900,"rrname":"mcj4.iad1.fsi.io.","rrtype":"NSEC","rdata":"i.mcj4.iad1.fsi.io. A RRSIG NSEC"}
```