### PR TITLE
Will now output ENTRY_TYPE_RDATA_NAME_REV records for NSEC records.

### DIFF
--- a/dnstable_convert.c
+++ b/dnstable_convert.c
@@ -469,6 +469,9 @@ process_rdata_name_rev(Nmsg__Sie__DnsDedupe *dns, size_t i, ubuf *key, ubuf *val
 	wdns_res res;
 
 	switch (dns->rrtype) {
+	case WDNS_TYPE_NSEC:
+		do_downcase = true;
+		/* fallthrough */
 	case WDNS_TYPE_SOA:
 		if (len == 0)
 			return;


### PR DESCRIPTION
This allows the following queries to work where previously they would not return any data.

  $ dnstable_lookup -j rdata name i.mcj4.iad1.fsi.io.
  {"count":13,"time_first":1637014235,"time_last":1637071900,"rrname":"mcj4.iad1.fsi.io.","rrtype":"NSEC","rdata":"i.mcj4.iad1.fsi.io. A RRSIG NSEC"}

  $ dnstable_lookup -j rdata name i.mcj4.iad1.fsi.*
  {"count":13,"time_first":1637014235,"time_last":1637071900,"rrname":"mcj4.iad1.fsi.io.","rrtype":"NSEC","rdata":"i.mcj4.iad1.fsi.io. A RRSIG NSEC"}