### PR TITLE
dnstable-convert 0.14.0 - Add block size, mtbl multithreading options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+dnstable-convert (0.14.0)
+
+  * dnstable_convert: Add -t <COUNT> option to specify the maximum number of
+  threads to use for the internal MTBL writer and sorter.
+
+  * dnstable_convert: Add -b <DNS_BSIZE[,DNSSEC_BSIZE]> option to set
+  DNS (and optionally DNSSEC) data block size.
+
+ -- Farsight Security Inc <software@farsightsecurity.com>  Tue, 30 July 2024 13:14:15 -0800
+
 dnstable-convert (0.13.0)
 
   * Add optional generation of source information metadata.

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_CHECK_HEADERS([sys/endian.h endian.h])
 
 PKG_CHECK_MODULES([libdnstable], [libdnstable])
 PKG_CHECK_MODULES([libnmsg], [libnmsg])
-PKG_CHECK_MODULES([libmtbl], [libmtbl])
+PKG_CHECK_MODULES([libmtbl], [libmtbl >= 1.7.0])
 PKG_CHECK_MODULES([libwdns], [libwdns])
 
 CPPFLAGS_SAVED=$CPPFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ(2.60)
-AC_INIT([dnstable-convert], [0.13.0])
+AC_INIT([dnstable-convert], [0.14.0])
 AC_CONFIG_SRCDIR([dnstable_convert.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign 1.11 -Wall -Wno-portability silent-rules subdir-objects])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dnstable-convert (0.14.0-1) debian-fsi; urgency=medium
+
+  * dnstable_convert: Add -t <COUNT> option to specify the maximum number of
+  threads to use for the internal MTBL writer and sorter.
+
+  * dnstable_convert: Add -b <DNS_BSIZE[,DNSSEC_BSIZE]> option to set
+  DNS (and optionally DNSSEC) data block size.
+
+ -- Farsight Security Inc <software@farsightsecurity.com>  Fri, 06 Dec 2024 15:58:59 -0500
+
 dnstable-convert (0.13.0-1) debian-fsi; urgency=medium
 
   * Add optional generation of source information metadata.

--- a/dnstable-convert.spec
+++ b/dnstable-convert.spec
@@ -1,6 +1,6 @@
 %global debug_package %{nil}
 Name:           dnstable-convert
-Version:        0.13.0
+Version:        0.14.0
 Release:        1%{?dist}
 Summary:        A utility for converting dnstable files to different formats
 

--- a/dnstable_convert.c
+++ b/dnstable_convert.c
@@ -230,7 +230,7 @@ do_stats(void)
 		count_messages,
 		count_entries_dns,
 		count_entries_dnssec,
-		count_entries_merged,
+		atomic_load_explicit(&count_entries_merged, memory_order_relaxed),
 		t_dur,
 		(int) (count_messages / t_dur),
 		(int) (count_entries_dns / t_dur), fd
@@ -250,7 +250,7 @@ merge_func(void *clos,
 			    val0, len_val0,
 			    val1, len_val1,
 			    merged_val, len_merged_val);
-	count_entries_merged += 1;
+	atomic_fetch_add_explicit(&count_entries_merged, 1, memory_order_relaxed);
 }
 
 static void
@@ -970,7 +970,7 @@ update_version_table(void)
 }
 
 static void
-init_mtbl(mtbl_compression_type compression, int level, size_t block_size, struct mtbl_threadpool *pool, size_t mem_mb)
+init_mtbl(mtbl_compression_type compression, int level, size_t dns_block_size, struct mtbl_threadpool *pool, size_t mem_mb)
 {
 	struct mtbl_sorter_options *sopt;
 	struct mtbl_writer_options *wopt;
@@ -990,22 +990,19 @@ init_mtbl(mtbl_compression_type compression, int level, size_t block_size, struc
 	wopt = mtbl_writer_options_init();
 
 	mtbl_writer_options_set_threadpool(wopt, pool);
-	mtbl_writer_options_set_block_size(wopt, block_size);
 
 	mtbl_writer_options_set_compression(wopt, compression);
 	if (level != DEFAULT_COMPRESSION_LEVEL)
 		mtbl_writer_options_set_compression_level(wopt, level);
 
-	if (block_size == 0)
-		mtbl_writer_options_set_block_size(wopt, DNS_MTBL_BLOCK_SIZE);
+	mtbl_writer_options_set_block_size(wopt, dns_block_size);
 	writer_dns = mtbl_writer_init(db_dns_fname, wopt);
 	if (writer_dns == NULL) {
 		perror(db_dns_fname);
 		exit(EXIT_FAILURE);
 	}
 
-	if (block_size == 0)
-		mtbl_writer_options_set_block_size(wopt, DNSSEC_MTBL_BLOCK_SIZE);
+	mtbl_writer_options_set_block_size(wopt, DNSSEC_MTBL_BLOCK_SIZE);
 	writer_dnssec = mtbl_writer_init(db_dnssec_fname, wopt);
 	if (writer_dnssec == NULL) {
 		perror(db_dnssec_fname);
@@ -1022,19 +1019,23 @@ init_mtbl(mtbl_compression_type compression, int level, size_t block_size, struc
 static void
 usage(const char *name)
 {
-	fprintf(stderr, "Usage: %s [-D] [-p] [-r] [-S] [-c compression] [-l level] [-b size] [-t threads] [-m megabytes] [-s NAME] <NMSG FILE> <DB FILE> <DB DNSSEC FILE>\n", name);
+	fprintf(stderr, "Usage: %s [-D] [-p] [-r] [-S] [-b size] [-c compression] "
+			"[-l level] [-m megabytes] [-s NAME] [-t threads] "
+			"<NMSG FILE> <DB FILE> <DB DNSSEC FILE>\n", name);
+
 	fprintf(stderr, "Options:\n"
-	" -c TYPE:  Use TYPE compression (Default: zlib)\n"
-	" -D:       Put CDS, CDNSKEY, and TA RRSets in both outputs\n"
-	" -l LEVEL: Use numeric LEVEL of compression.\n"
-	"           Default varies based on TYPE.\n"
-	" -b SIZE:  The uncompressed data block size hint for the output file..\n"
-	" -t COUNT: Use a maximum of COUNT threads during sorting and writing.\n"
-	" -m MMB:   Specify maximum amount of memory to use for in-memory sorting, in megabytes.\n"
-	" -p:       Preserve empty DNS/DNSSEC files.\n"
-	" -r:       Emit RDATA and RDATA_NAME_REV dnstable entries for SOA rname field.\n"
-	" -s NAME:  NMSG source information to include in output if input is stdin.\n"
-	" -S:       Include nmsg source information in output.\n");
+		" -b SIZE:  set mtbl block size to use for DB FILE (default: %u).\n"
+		" -c TYPE:  use type compression (default: zlib)\n"
+		" -D:       put cds, cdnskey, and ta rrsets in both outputs\n"
+		" -l LEVEL: use numeric level of compression.\n"
+		"           default varies based on type.\n"
+		" -m MMB:   specify maximum amount of memory to use for in-memory sorting, in megabytes.\n"
+		" -p:       preserve empty dns/dnssec files.\n"
+		" -r:       emit rdata and rdata_name_rev dnstable entries for soa rname field.\n"
+		" -s NAME:  nmsg source information to include in output if input is stdin.\n"
+		" -s:       include nmsg source information in output.\n"
+		" -t COUNT: set size of mtbl thread pool for sorting and writing.\n",
+		DNS_MTBL_BLOCK_SIZE);
 }
 
 int
@@ -1043,7 +1044,7 @@ main(int argc, char **argv)
 	long mmb = 0;
 	mtbl_compression_type compression = MTBL_COMPRESSION_ZLIB;
 	int compression_level = DEFAULT_COMPRESSION_LEVEL;
-	int block_size = 0;
+	int dns_block_size = DNS_MTBL_BLOCK_SIZE;
 	int thread_count = 0;
 	struct mtbl_threadpool *pool = NULL;
 	const char *name = argv[0];
@@ -1051,11 +1052,19 @@ main(int argc, char **argv)
 
 	setlocale(LC_ALL, "");
 
-	while ((c = getopt(argc, argv, "Dc:l:t:b:m:prSs:")) != -1) {
+	while ((c = getopt(argc, argv, "b:Dc:l:m:t:prSs:")) != -1) {
 		mtbl_res res;
 		char *end;
 
 		switch(c) {
+		case 'b':
+			dns_block_size = strtol(optarg, &end, 10);
+			if (*end != '\0' || dns_block_size < 1) {
+				fprintf(stderr, "Invalid DNS block size '%s'\n", optarg);
+				usage(name);
+				return (EXIT_FAILURE);
+			}
+			break;
 		case 'D':
 			migrate_dnssec = true;
 			break;
@@ -1075,26 +1084,18 @@ main(int argc, char **argv)
 				return (EXIT_FAILURE);
 			}
 			break;
-		case 'b':
-			block_size = atoi(optarg);
-			if (block_size < 1) {
-				fprintf(stderr, "Invalid block size '%s'\n", optarg);
+		case 'm':
+			mmb = strtol(optarg, &end, 10);
+			if (*end != '\0' || mmb <= 0) {
+				fprintf(stderr, "Invalid max mega bytes '%s'\n", optarg);
 				usage(name);
 				return (EXIT_FAILURE);
 			}
 			break;
 		case 't':
-			thread_count = atoi(optarg);
-			if (thread_count < 0) {
+			thread_count = strtol(optarg, &end, 10);
+			if (*end != '\0' || thread_count < 0) {
 				fprintf(stderr, "Invalid thread count '%s'\n", optarg);
-				usage(name);
-				return (EXIT_FAILURE);
-			}
-			break;
-		case 'm':
-			mmb = strtol(optarg, &end, 10);
-			if (*end != '\0' || mmb <= 0) {
-				fprintf(stderr, "Invalid max mega bytes '%s'\n", optarg);
 				usage(name);
 				return (EXIT_FAILURE);
 			}
@@ -1149,7 +1150,7 @@ main(int argc, char **argv)
 	init_nmsg();
 
 	pool = mtbl_threadpool_init(thread_count);
-	init_mtbl(compression, compression_level, block_size, pool, (size_t)mmb);
+	init_mtbl(compression, compression_level, dns_block_size, pool, (size_t)mmb);
 
 	nmsg_timespec_get(&start_time);
 	do_read();

--- a/man/dnstable_convert.1
+++ b/man/dnstable_convert.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: dnstable_convert
-.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 01/26/2024
+.\"    Author: [FIXME: author] [see http://www.docbook.org/tdg5/en/html/author]
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 07/30/2024
 .\"    Manual: \ \&
 .\"    Source: \ \&
 .\"  Language: English
 .\"
-.TH "DNSTABLE_CONVERT" "1" "01/26/2024" "\ \&" "\ \&"
+.TH "DNSTABLE_CONVERT" "1" "07/30/2024" "\ \&" "\ \&"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 dnstable_convert \- convert passive DNS NMSG data to dnstable MTBL format
 .SH "SYNOPSIS"
 .sp
-\fBdnstable_convert\fR [\fB\-DprS\fR] [\fB\-c TYPE\fR] [\fB\-l LEVEL\fR] [\fB\-m #\fR] [\fB\-s NAME\fR] \fINMSG\-FILE\fR \fIDB\-DNS\-FILE\fR \fIDB\-DNSSEC\-FILE\fR
+\fBdnstable_convert\fR [\fB\-DprS\fR] [\fB\-b DNS_BSIZE[,DNSSEC_BSIZE]\fR] [\fB\-c TYPE\fR] [\fB\-l LEVEL\fR] [\fB\-m #\fR] [\fB\-s NAME\fR] [\fB\-t COUNT\fR] \fINMSG\-FILE\fR \fIDB\-DNS\-FILE\fR \fIDB\-DNSSEC\-FILE\fR
 .SH "DESCRIPTION"
 .sp
 Converts passive DNS data from NMSG format to MTBL format\&. The input NMSG data in \fINMSG\-FILE\fR must be encoded using the SIE/dnsdedupe message schema, and the output data will be written to two separate MTBL files: the \fIDB\-DNS\-FILE\fR containing "plain" DNS records, and the \fIDB\-DNSSEC\-FILE\fR, containing DNSSEC\-related records\&.
@@ -50,6 +50,11 @@ By default, \fBdnstable_convert\fR will use \fB/var/tmp/\fR to store temporary m
 \fB\-D\fR
 .RS 4
 This flag enables a transitional compatibility mode described above\&.
+.RE
+.PP
+\fB\-b DNS_BSIZE[,DNSSEC_BSIZE]\fR
+.RS 4
+Produce the DNS MTBL output file using a data block size of DNS_BSIZE bytes, optionally producing the DNSSEC MTBL output file using a data block size of DNSSEC_BSIZE\&.
 .RE
 .PP
 \fB\-c TYPE\fR
@@ -86,4 +91,9 @@ Source metadata to include in output\&. Required if input is stdin, otherwise de
 \fB\-S\fR
 .RS 4
 Include nmsg source information in output\&.
+.RE
+.PP
+\fB\-t COUNT\fR
+.RS 4
+Use an MTBL thread pool of COUNT worker threads for sorting and writing (default is zero)\&.
 .RE

--- a/man/dnstable_convert.1.txt
+++ b/man/dnstable_convert.1.txt
@@ -6,7 +6,7 @@ dnstable_convert - convert passive DNS NMSG data to dnstable MTBL format
 
 == SYNOPSIS ==
 
-^dnstable_convert^ [^-DprS^] [^-c TYPE^] [^-l LEVEL^] [^-m #^] [^-s NAME^] 'NMSG-FILE' 'DB-DNS-FILE' 'DB-DNSSEC-FILE'
+^dnstable_convert^ [^-DprS^] [^-b DNS_BSIZE[,DNSSEC_BSIZE]^] [^-c TYPE^] [^-l LEVEL^] [^-m #^] [^-s NAME^] [^-t COUNT^] 'NMSG-FILE' 'DB-DNS-FILE' 'DB-DNSSEC-FILE'
 
 == DESCRIPTION ==
 
@@ -48,6 +48,11 @@ be useful.
 ^-D^::
     This flag enables a transitional compatibility mode described above.
 
+^-b DNS_BSIZE[,DNSSEC_BSIZE]^::
+    Produce the DNS MTBL output file using a data block size of DNS_BSIZE bytes,
+    optionally producing the DNSSEC MTBL output file using a data block size of
+    DNSSEC_BSIZE.
+
 ^-c TYPE^::
     Use TYPE compression (Default: zlib).
 
@@ -71,3 +76,6 @@ be useful.
 
 ^-S^::
     Include nmsg source information in output.
+
+^-t COUNT^::
+    Use an MTBL thread pool of COUNT worker threads for sorting and writing (default is zero).


### PR DESCRIPTION
- Add -b option to specify uncompressed data block size for output files.
- Add -t option to enable multithreading (see mtbl PR #84).